### PR TITLE
stop packer from failing on second bakes

### DIFF
--- a/packer/amz_ebs_ami.json
+++ b/packer/amz_ebs_ami.json
@@ -27,9 +27,9 @@
   "provisioners": [
     {
       "type": "shell",
-      "inline": ["sudo mkdir /etc/chef",
+      "inline": ["sudo mkdir -p /etc/chef",
         "sudo chmod -R 777 /etc/chef",
-        "mkdir /tmp/packer-chef-client/",
+        "mkdir -p /tmp/packer-chef-client/",
         "chmod 0755 /tmp/packer-chef-client"
       ]
     },

--- a/packer/amz_win_esb_sub_ami.json
+++ b/packer/amz_win_esb_sub_ami.json
@@ -53,12 +53,6 @@
           "app_build_sha": "{{user `build_sha`}}"
         }
       }
-    },
-    {
-      "type": "windows-shell",
-      "inline": [
-        "\"%ProgramFiles%\"\\Amazon\\Ec2ConfigService\\ec2config.exe -sysprep"
-      ]
     }
   ],
   "variables": {


### PR DESCRIPTION
Packer is failing if the directory already exists.
