### PR TITLE
SSH Timeout

### DIFF
--- a/bakery
+++ b/bakery
@@ -83,6 +83,11 @@ if [[ ! x${SOURCE_AMI} == "x" ]]; then
   log info "using custom base ami ${SOURCE_AMI}"
 fi
 
+if [[ ! x${PACKER_SSH_TIMEOUT} == "x" ]]; then
+  CLI_OPTS="${CLI_OPTS} -var ssh_timeout=${PACKER_SSH_TIMEOUT}"
+  log info "using ssh timeout of ${PACKER_SSH_TIMEOUT} seconds"
+fi
+
 if [[ ! x${7} == "x" ]]; then
   CLI_OPTS="${CLI_OPTS} -var build_id=${7}"
   log info "using build_id ${7}"

--- a/packer/amz_docker_ebs_ami.json
+++ b/packer/amz_docker_ebs_ami.json
@@ -13,6 +13,7 @@
     "vpc_id":	"{{ user `vpc_id` }}",
     "subnet_id": "{{ user `subnet_id` }}",
     "ssh_username": "ec2-user",
+    "ssh_timeout":"{{ user `ssh_timeout`}}",
     "ssh_pty": true,
     "security_group_id": "{{ user `security_group` }}",
     "ami_block_device_mappings": [
@@ -126,6 +127,7 @@
     "packer_instance_profile":"packer",
     "instance_type":"m3.medium",
     "bake_volume_size":"8",
-    "docker_volume_size":"8"
+    "docker_volume_size":"8",
+    "ssh_timeout":"5m"
   }
 }

--- a/packer/amz_ebs_ami.json
+++ b/packer/amz_ebs_ami.json
@@ -15,6 +15,7 @@
     "ssh_username": "{{ user `ssh_username` }}",
     "ssh_pty": true,
     "security_group_id": "{{ user `security_group` }}",
+    "ssh_timeout":"{{ user `ssh_timeout`}}",
     "run_tags": {
       "Name": "Packer {{ user `ami_name` }} (Amazon Linux)"
     },
@@ -109,6 +110,7 @@
     "packer_instance_profile":"packer",
     "instance_type":"m3.medium",
     "bake_volume_size":"8",
+    "ssh_timeout":"5m",
     "device_name":"/dev/xvda",
     "ssh_username":"ec2-user"
   }


### PR DESCRIPTION
# Change

Added configurable SSH timeout for packer.  https://www.packer.io/docs/templates/communicator.html

# Solved problem

In some cases it takes bit longer for Amazon to spin up new instance, and for packer to connect to it. Bake process fails if packer is unable to connect within 2 minutes to the instance. This PR resolved problem by allowing configuration of timeout period through `PACKER_SSH_TIMEOUT` environment variable. Additionally, for Amazon EBS and Docker template, SSH timeout is set to default to 5 minutes compared to packer's default of 2 minutes. 

## Testing 

Change has been tested with manually running bakery