### PR TITLE
fixing 7z command to be 7z instead of 7za

### DIFF
--- a/scripts/win2016/download_cookbooks.ps1
+++ b/scripts/win2016/download_cookbooks.ps1
@@ -28,8 +28,8 @@ try
   }
 
   Write-Output "INFO: Extracting $GzipPath to $CookbookDir"
-  7za x $GzipPath -o"$Base2Path" -y
-  7za x $TarPath -o"$Destination" -y
+  7z x $GzipPath -o"$Base2Path" -y
+  7z x $TarPath -o"$Destination" -y
 
   Write-Output "INFO: Cleaning up $GzipPath $TarPath"
   rm $GzipPath


### PR DESCRIPTION
Fixing error appearing during baking windows instances

"1519954171,,ui,message,    amazon-ebs: ERROR: Exception Message: The term '7za' is not recognized as the name of a cmdlet%!(PACKER_COMMA) function%!(PACKER_COMMA) script file%!(PACKER_COMMA) or operable program. Check the spelling of the name%!(PACKER_COMMA) or if a path was included%!(PACKER_COMMA) verify that the path is correct and try again."